### PR TITLE
Enable expo-router app pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ npm install
 npx expo start
 ```
 
-The mobile app uses **expo-router** with an `app` directory for file-based routing. Modify files under `expo-app/app/` to add new screens and layouts.
+The mobile app uses **expo-router** with an `app` directory for file-based routing.
+Screens live in `expo-app/src/screens` and are imported from the route files under `expo-app/app/`.
+Shared UI components can be placed in `expo-app/src/components`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Here's a professional, Codex-ready **`README.md` section** you can add to your r
 ## 🚀 Codex Task: Build a Scalable eCommerce UI Kit
 
 Welcome, Codex contributors! This repository is focused on building a **fully responsive, reusable, and accessible eCommerce UI Kit** using modern frontend best practices.
-It now includes a basic **Expo** setup in `expo-app/` so you can prototype mobile views alongside the web components.
+It now includes a basic **Expo** setup in `expo-app/` using the modern `app` directory powered by **expo-router**. This allows you to prototype mobile views with file-based routing alongside the web components.
 
 ---
 
@@ -68,8 +68,10 @@ git clone https://github.com/sitharaj88/ecommerece-ui-kit
 cd ecommerece-ui-kit
 cd expo-app
 npm install
-npm start
+npx expo start
 ```
+
+The mobile app uses **expo-router** with an `app` directory for file-based routing. Modify files under `expo-app/app/` to add new screens and layouts.
 
 ---
 

--- a/expo-app/app/_layout.tsx
+++ b/expo-app/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/expo-app/app/_layout.tsx
+++ b/expo-app/app/_layout.tsx
@@ -1,5 +1,13 @@
 import { Stack } from 'expo-router';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 export default function RootLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <Stack screenOptions={{ headerShown: false }} />
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
+  );
 }

--- a/expo-app/app/index.tsx
+++ b/expo-app/app/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
-export default function App() {
+export default function HomeScreen() {
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+      <Text>Open up app/index.tsx to start working on your app!</Text>
       <StatusBar style="auto" />
     </View>
   );

--- a/expo-app/app/index.tsx
+++ b/expo-app/app/index.tsx
@@ -1,21 +1,5 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { StatusBar } from 'expo-status-bar';
+import HomeScreen from '@screens/HomeScreen';
 
-export default function HomeScreen() {
-  return (
-    <View style={styles.container}>
-      <Text>Open up app/index.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
-  );
+export default function Index() {
+  return <HomeScreen />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/expo-app/package.json
+++ b/expo-app/package.json
@@ -2,7 +2,7 @@
   "name": "expo-app",
   "version": "0.1.0",
   "private": true,
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
@@ -16,7 +16,10 @@
     "react-dom": "18.2.0",
     "react-native": "0.72.3",
     "react-native-web": "~0.19.6",
-    "@types/react": "~18.2.14"
+    "@types/react": "~18.2.14",
+    "expo-router": "^2.0.0",
+    "react-native-safe-area-context": "^4.7.0",
+    "react-native-screens": "^3.22.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/expo-app/package.json
+++ b/expo-app/package.json
@@ -19,7 +19,8 @@
     "@types/react": "~18.2.14",
     "expo-router": "^2.0.0",
     "react-native-safe-area-context": "^4.7.0",
-    "react-native-screens": "^3.22.0"
+    "react-native-screens": "^3.22.0",
+    "react-native-gesture-handler": "^2.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/expo-app/src/screens/HomeScreen.tsx
+++ b/expo-app/src/screens/HomeScreen.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Open up app/index.tsx to start working on your app!</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/expo-app/tsconfig.json
+++ b/expo-app/tsconfig.json
@@ -14,9 +14,12 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": [
-      "expo-router"
-    ]
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@screens/*": ["src/screens/*"]
+    },
+    "types": ["expo-router"]
   },
   "include": [
     "**/*.ts",

--- a/expo-app/tsconfig.json
+++ b/expo-app/tsconfig.json
@@ -13,7 +13,10 @@
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": [
+      "expo-router"
+    ]
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
## Summary
- adopt Expo Router's `app` directory
- add routing dependencies and safe area modules
- update TypeScript config for Expo Router
- document updated start instructions

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_684101499ff4832686cfd5c7c6dce73b